### PR TITLE
fix: mappings in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,6 @@ COPY . .
 RUN cargo install --path .
 
 EXPOSE 8080
-CMD ["lisho", "/mappings", "0.0.0.0:8080"]
+CMD ["lisho", "mappings.txt", "0.0.0.0:8080"]
 
 


### PR DESCRIPTION
README.md uses mappings.txt, says it reads from a single file, not a directory update Dockerfile to reflect that