### PR TITLE
Slim down docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:latest as builder
+FROM rust:slim as builder
 WORKDIR /usr/src/lisho
 COPY . .
 RUN cargo install --path .


### PR DESCRIPTION
use `slim` instead of `latest`, saves around 700 MB of disk space for the image